### PR TITLE
Update 时间线TIMELINE.md

### DIFF
--- a/时间线TIMELINE.md
+++ b/时间线TIMELINE.md
@@ -310,8 +310,10 @@
 * [受习近平总书记委托 李克强总理（中央应对新型冠状病毒感染肺炎疫情工作领导小组组长）赴汉考察指导疫情防控。](http://www.hubei.gov.cn/zwgk/hbyw/hbywqb/202001/t20200128_2015593.shtml)<br>
 * 稳健医疗发布公告[《这些天，稳健医疗做了什么》](http://www.winnermedical.cn/cn/newsdetail/106/666.html)。<br>
 
+
 【国际】<br>
 * [世卫组织在26日、27日的新型冠状病毒报告中，将新型冠状病毒疫情全球范围风险改为高风险。](https://weibo.com/2656274875/IryC5cLh5?type=comment#_rnd1580291594764)<br>
+* （香港讯）武汉肺炎疫情持续扩散，香港大学微生物学研究团队在医学杂志《柳叶刀》(The Lancet)发表文章，以深圳一个七人家庭中有六人确诊的群组病例，推算出病毒对家庭成员的攻击率(attack rate)高达83%，且证实能人传人。（新加坡联合早报）( http://www.zaobao.com/news/china/story20200127-1023950?utm_source=ZB_iPhone&utm_medium=share)<br>
 
 ## 2020年1月28日 初四
 【武汉-湖北】<br>

--- a/时间线TIMELINE.md
+++ b/时间线TIMELINE.md
@@ -310,10 +310,9 @@
 * [受习近平总书记委托 李克强总理（中央应对新型冠状病毒感染肺炎疫情工作领导小组组长）赴汉考察指导疫情防控。](http://www.hubei.gov.cn/zwgk/hbyw/hbywqb/202001/t20200128_2015593.shtml)<br>
 * 稳健医疗发布公告[《这些天，稳健医疗做了什么》](http://www.winnermedical.cn/cn/newsdetail/106/666.html)。<br>
 
-
 【国际】<br>
 * [世卫组织在26日、27日的新型冠状病毒报告中，将新型冠状病毒疫情全球范围风险改为高风险。](https://weibo.com/2656274875/IryC5cLh5?type=comment#_rnd1580291594764)<br>
-* （香港讯）武汉肺炎疫情持续扩散，香港大学微生物学研究团队在医学杂志《柳叶刀》(The Lancet)发表文章，以深圳一个七人家庭中有六人确诊的群组病例，推算出病毒对家庭成员的攻击率(attack rate)高达83%，且证实能人传人。（新加坡联合早报）( http://www.zaobao.com/news/china/story20200127-1023950?utm_source=ZB_iPhone&utm_medium=share)<br>
+* [新加坡联合早报](http://www.zaobao.com/news/china/story20200127-1023950?utm_source=ZB_iPhone&utm_medium=share)载香港讯，武汉肺炎疫情持续扩散，香港大学微生物学研究团队在医学杂志《柳叶刀》(The Lancet)发表文章，以深圳一个七人家庭中有六人确诊的群组病例，推算出病毒对家庭成员的攻击率(attack rate)高达83%，且证实能人传人。<br>
 
 ## 2020年1月28日 初四
 【武汉-湖北】<br>


### PR DESCRIPTION
1月27日
【国际】
（香港讯）武汉肺炎疫情持续扩散，香港大学微生物学研究团队在医学杂志《柳叶刀》(The Lancet)发表文章，以深圳一个七人家庭中有六人确诊的群组病例，推算出病毒对家庭成员的攻击率(attack rate)高达83%，且证实能人传人。（[新加坡联合早报]( http://www.zaobao.com/news/china/story20200127-1023950?utm_source=ZB_iPhone&utm_medium=share)）